### PR TITLE
bad use of global

### DIFF
--- a/lib/commands/push/build.js
+++ b/lib/commands/push/build.js
@@ -78,6 +78,7 @@ Build.prototype._deploymentData = function (files) {
   var self = this;
   
   return function (data) {
+    verbose('EVENT: ', data);
     switch (data.event) {
       case 'unpack':
         self.emit('unpack', data.data.path);

--- a/lib/commands/push/index.js
+++ b/lib/commands/push/index.js
@@ -56,8 +56,9 @@ module.exports = function (app) {
         
         function packageAndUploadBuild (next) {
           app.logger.info('Deploying build ... ');
-          
+          verbose(build.build);
           build.package(function (err, unreleased) {
+            verbose('build.package callback', {err:err, unreleased:unreleased});
             if (unreleased.length) {
               app.logger.info(unreleased);
               return next('ERROR: Not all files released!');

--- a/lib/divshot.js
+++ b/lib/divshot.js
@@ -40,6 +40,7 @@ module.exports = function (options) {
     .option('--token [token]', 'manually pass access token')
     .option('--app [app]', 'manually supply the ' + app.format.blue('Divshot.io') + ' app name')
     .option('--no-color', 'strip all use of color in output')
+    .option('--verbose', 'log verbose messages (MIGHT BE RATHER VERBOSE)')
     .on('-v', function () {
       app.logger.info(package.version);
     });

--- a/lib/program.js
+++ b/lib/program.js
@@ -27,6 +27,15 @@ module.exports = function (api, user, cwd) {
         api.setToken(this.token);
         user.attributes.token = this.token;
       }
+
+      if (this.rawArgs.indexOf('--verbose') > -1) {
+        global.verbose = function() {
+          console.info.apply(console, Array.prototype.concat.apply(['verbose: '], arguments));
+        }
+      }
+      else {
+        global.verbose = function() {};
+      }
       
       if (this.rawArgs.indexOf('--no-color') > -1) feedback.color = false;
       


### PR DESCRIPTION
Obviously `global.verbose` is the wrong place for this, but I can't immediately figure out where to hang the verbose logging function to make it show up as app.logger.verbose.

@scottcorgan can you help me with this?

@mbleigh Then if we cant figure out a way to replicate this, can we figure out a way to set this up as an option on travis and then we can just run deploys of a dummy project until we see a bad build and can check the logs.
