### PR TITLE
Remove hard-coded position of environment argument.

### DIFF
--- a/lib/commands/env.js
+++ b/lib/commands/env.js
@@ -10,9 +10,6 @@ module.exports = function (cli) {
   function withApp(callback) {
     
     return function (environment, done) {
-      
-      environment = process.argv[3];
-      
       callback(cli.api.apps.id(cli.cwd.getConfig().name), environment, done);      
     }
   }


### PR DESCRIPTION
Supplying any global command-line arguments, such as -a or -c, currently causes the env command to fail. The cause of this failure is the hard-coded position of the environment argument. Removing this unnecessary assignment resolves this problem.